### PR TITLE
Proposal for Verilatio Protocol

### DIFF
--- a/spec.asyncapi.yaml
+++ b/spec.asyncapi.yaml
@@ -1,0 +1,70 @@
+asyncapi: 2.0.0
+info:
+  title: Verilatio Protocol
+  version: 0.1.0
+  description: Describes a websocket simulator driver protocol. Sort of like a cosimulation RPC layer.
+channels:
+  /:
+    publish:
+      description: Command sent from client to simulator.
+      message:
+        $ref: '#/components/messages/ToSimulator'
+    subscribe:
+      description: The current state of the simulator sent to the client.
+      message:
+        $ref: '#/components/messages/FromSimulator'
+components:
+  messages:
+    ToSimulator:
+      payload:
+        type: object
+        properties:
+          simulatorAction:
+            enum: ["none", "step", "run", "pause", "restart"]
+            example: "step"
+            description: controls the simulators running state.
+          subscribeTo:
+            type: array
+            items:
+              type: string
+              description: the signal identifier
+              example: "led_0"
+            description: subscribes to changes in signal values. This only needs to be sent ONCE for the duration of the websocket session.
+          setValue:
+            description: sets the values of a set of signals.
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: the signal identifier
+                  example: "sw1"
+                value:
+                  type: number
+    FromSimulator:
+      payload:
+        type: object
+        properties:
+          simulatorState:
+            enum: ["initial", "running", "paused", "finished"]
+          time:
+            type: object
+            required: ["value"]
+            properties:
+              value:
+                type: number
+              unit:
+                enum: ["ticks","ps","ns","us","ms","s"]
+          valueChanges:
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: the signal identifier
+                  example: "led_0"
+                value:
+                  type: number
+            

--- a/spec.asyncapi.yaml
+++ b/spec.asyncapi.yaml
@@ -10,7 +10,14 @@ channels:
       message:
         $ref: '#/components/messages/ToSimulator'
     subscribe:
-      description: The current state of the simulator sent to the client.
+      description: |
+        The current state of the simulator sent to the client.
+        This may be published by the simulator at any time, but it
+        _must_ be published under the following circumstances:
+        
+        1. When the websocket connection is established (initial simulator state and time)
+        2. When a command with subscribe is sent (initial signal value)
+        3. When the simulation completes or unexpectedly stops
       message:
         $ref: '#/components/messages/FromSimulator'
 components:
@@ -67,4 +74,11 @@ components:
                   example: "led_0"
                 value:
                   type: number
-            
+          errors:
+            type: array
+            items:
+              type: object
+              properties:
+                message:
+                  type: string
+              required: ["message"]


### PR DESCRIPTION
Hey Olof, 

I had a few ideas about the specification. So I put my ideas into an AsyncAPI spec. Feel free to pull any ideas from it that you like.

View the rendered spec [here](https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/nturley/verilatio/main/spec.asyncapi.yaml)

Key points:
* Use AsyncAPI to specify a schema
* More comprehensive simulator commands (start, pause, step, restart)
* Allow clients to subscribe to only the signals they care about.
  * Maybe we should also add unsubscribe?
*  Only use numbers for signal values. This is great for cxxrtl and verilator. Okay for iicarus, Not very great for ghdl.
* For development debugging and assertion errors

I did not add introspection commands, or data type fields even though that would be pretty useful. Both sides will just need to agree on what signals exist and what their data types are.
